### PR TITLE
update to more current requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.17.3
 scipy>=1.3.1
-scikit-learn>=0.21.3
+scikit-learn>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
+requirements = [str(r.requirement) for r in parse_requirements('requirements.txt', session=False)]
 
 setup_requirements = ['pytest-runner', ]
 

--- a/student_mixture/__init__.py
+++ b/student_mixture/__init__.py
@@ -11,12 +11,12 @@ import sys
 if (sys.version_info < (3, 3)):
     from student_mixture import StudentMixture
     from multivariate_t import multivariate_t as multivariate_t
-    from mutlivariate_t_fit import MultivariateTFit
+    from multivariate_t_fit import MultivariateTFit
 
 else:
     from student_mixture.student_mixture import StudentMixture
     from student_mixture.multivariate_t import multivariate_t  as multivariate_t
-    from student_mixture.mutlivariate_t_fit import MultivariateTFit
+    from student_mixture.multivariate_t_fit import MultivariateTFit
 
 __all__ = ['StudentMixture',
            'multivariate_t',

--- a/student_mixture/multivariate_t_fit.py
+++ b/student_mixture/multivariate_t_fit.py
@@ -13,7 +13,7 @@ import warnings
 
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
-from sklearn.utils.fixes import logsumexp
+from scipy.special import logsumexp
 
 from ._multivariate_t_fit_functions import (_check_X, _check_location, _check_dof, _check_precision,
                                             _estimate_student_parameters, _compute_precision_cholesky,

--- a/student_mixture/student_mixture.py
+++ b/student_mixture/student_mixture.py
@@ -261,7 +261,7 @@ class StudentMixture(GaussianMixture):
                              "non-negative"
                              % self.reg_scale)
                              
-        super()._check_initial_parameters(X)
+        super()._check_parameters(X)
 
         if self.algorithm not in ['em', 'mcecm']:
             raise ValueError("Invalid value for 'algorithm': %s "
@@ -398,7 +398,7 @@ class StudentMixture(GaussianMixture):
                     self.converged_ = True
                     break
 
-            self._print_verbose_msg_init_end(lower_bound)
+            self._print_verbose_msg_init_end(lower_bound, self.converged_)
 
             if lower_bound > max_lower_bound:
                 max_lower_bound = lower_bound


### PR DESCRIPTION
Thanks for creating and sharing this repository! I've found it very helpful, but I had to do a bit of minor work to get it up and running on my somewhat-current venv.

The issues I encountered:
- could not install via `pip3 install -e .` or `pip3 install .`
- once installed, could not import due to missing `logsumexp`
- once imported, could not initialize due to missing `super()._check_initial_parameters()`
- once initialized, verbose output threw either a warning or exception when `BaseMixture` was expecting to get `self.converged_` passed in the call to `_print_verbose_msg_init_end`

I also noticed a misspelling in one of the filenames, so I updated that as well.

I have not confirmed that all functionality and options work correctly with these changes in place; I've just confirmed that a basic initialization with `random_state`, `n_components`, `n_init`, and `verbose=10` followed by `.fit_predict()` yields the expected results on a synthetic mixture.

I have also not confirmed that these changes retain compatibility with Python2, since it seems like scikit-learn has itself dropped support for Python2.

I initiated a discussion [here](https://github.com/scikit-learn/scikit-learn/issues/29616) about possibly integrating this code into scikit-learn because I've found this code to be so helpful and thought others might as well, but the initial feedback I received seemed pretty cautious, hence I wanted to help keep this repo current and relevant.

I am happy to add new commits to make any additional changes or fix any unexpectedly-introduced bugs & look forward to hearing your thoughts about this changeset!