### PR TITLE
change np.infty to np.inf to remain compatible with Numpy >= 2.0

### DIFF
--- a/student_mixture/multivariate_t_fit.py
+++ b/student_mixture/multivariate_t_fit.py
@@ -304,7 +304,7 @@ class MultivariateTFit():
 
         self._initialize(X)
 
-        lower_bound = -np.infty
+        lower_bound = -np.inf
 
         for n_iter in range(1, self.max_iter + 1):
             prev_lower_bound = lower_bound

--- a/student_mixture/student_mixture.py
+++ b/student_mixture/student_mixture.py
@@ -370,7 +370,7 @@ class StudentMixture(GaussianMixture):
         do_init = not(self.warm_start and hasattr(self, 'converged_'))
         n_init = self.n_init if do_init else 1
 
-        max_lower_bound = -np.infty
+        max_lower_bound = -np.inf
         self.converged_ = False
 
         random_state = check_random_state(self.random_state)
@@ -381,7 +381,7 @@ class StudentMixture(GaussianMixture):
             if do_init:
                 self._initialize_parameters(X, random_state)
 
-            lower_bound = (-np.infty if do_init else self.lower_bound_)
+            lower_bound = (-np.inf if do_init else self.lower_bound_)
 
             for n_iter in range(1, self.max_iter + 1):
                 prev_lower_bound = lower_bound


### PR DESCRIPTION
`np.infty` has been removed from NumPy as of release 2.0. Fortunately, `np.inf` is present in the minimum NumPy version currently in `requirements.txt` (1.17.3). This PR updates 3 references to `np.infty` to `np.inf` to enable use on current NumPy.